### PR TITLE
Add button and command that allows inverting contrast of tomograms.

### DIFF
--- a/bundle_info.xml
+++ b/bundle_info.xml
@@ -195,6 +195,9 @@ will be displayed without the ChimeraX- prefix.
       name="YZ" icon="view_yz.png" description="Set viewing direction to YZ planes."/>
     <Provider tab="ArtiaX" section="View"
       name="Clip" icon="clip.png" description="Turn slab-clipping on or off for all tomograms."/>
+    <Provider tab="ArtiaX" section="View"
+      name="Invert Contrast" icon="invert_contrast.png" description="Invert contrast of visible tomograms."/>
+
 
     <!-- ArtiaX tab, Standard Mouse Modes -->
     <Provider tab="ArtiaX" section="Movement" mouse_mode="select"
@@ -472,6 +475,9 @@ will be displayed without the ChimeraX- prefix.
 
     <ChimeraXClassifier>ChimeraX :: Command :: artiax cap :: General ::
       Turn on/off surface capping for particle lists.</ChimeraXClassifier>
+
+    <ChimeraXClassifier>ChimeraX :: Command :: artiax invert :: General ::
+      Invert the contrast of specified or all visible tomograms.</ChimeraXClassifier>
 
   </Classifiers>
 </BundleInfo>

--- a/bundle_info.xml
+++ b/bundle_info.xml
@@ -6,7 +6,7 @@ will be displayed without the ChimeraX- prefix.
 -->
 
 <BundleInfo name="ChimeraX-ArtiaX"
-	    version="0.4.8" package="chimerax.artiax"
+	    version="0.4.9" package="chimerax.artiax"
   	    minSessionVersion="1" maxSessionVersion="1">
 
   <!-- Additional information about bundle source -->

--- a/src/docs/user/commands/artiax_clip.html
+++ b/src/docs/user/commands/artiax_clip.html
@@ -2,7 +2,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=windows-1252">
     <link rel="stylesheet" type="text/css" href="../userdocs.css">
-    <title>Command: artiax info</title>
+    <title>Command: artiax clip</title>
   </head>
   <body> <a name="top"></a> <a href="../artiax_index.html"> <img src="../ArtiaX-docs-icon.svg"
         alt="ChimeraX docs icon" class="clRight" title="User Guide Index" width="60px"></a>

--- a/src/docs/user/commands/artiax_invert.html
+++ b/src/docs/user/commands/artiax_invert.html
@@ -2,18 +2,17 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=windows-1252">
     <link rel="stylesheet" type="text/css" href="../userdocs.css">
-    <title>Command: artiax cap</title>
+    <title>Command: artiax invert</title>
   </head>
   <body> <a name="top"></a> <a href="../artiax_index.html"> <img src="../ArtiaX-docs-icon.svg"
         alt="ChimeraX docs icon" class="clRight" title="User Guide Index" width="60px"></a>
-    <h3><a href="../artiax_index.html#commands">Command</a>: artiax cap</h3>
+    <h3><a href="../artiax_index.html#commands">Command</a>: artiax invert</h3>
     <h3 class="usage"><a href="usageconventions.html">Usage</a>: <br><b>artiax
-      cap</b> ( <i>true</i> | <i>false</i> ) </h3>
-    <p> The <b>artiax cap</b> command allows turning on/off surface caps for the particle list axes and surface visualization. Turning off will increase performance for older machines. 
-
+      invert</b> [ <b>model</b> <a href="atomspec.html#hierarchy"><i>model-spec</i></a>  ]</h3>
+    <p> The <b>artiax invert</b> command allows inverting the rendered contrast in the specified tomogram models. If
+    no models are specified, contrast of all visible models is inverted. </p>
     <p> Examples: </p>
-    <blockquote> <b>artiax cap true<br>
-      artiax cap false<br>
+    <blockquote> <b>artiax invert #1.1.1<br>
       </b> </blockquote>
     <p></p>
     <hr>

--- a/src/docs/user/commands/artiax_tomo.html
+++ b/src/docs/user/commands/artiax_tomo.html
@@ -9,8 +9,10 @@
     <h3><a href="../artiax_index.html#commands">Command</a>: artiax tomo</h3>
     <h3 class="usage"><a href="usageconventions.html">Usage</a>: <br>
       <b>artiax tomo</b> <a href="atomspec.html#hierarchy"><i>model-spec</i></a>&nbsp;[<strong>contrasCenter</strong>
-      <em>value</em>] [<strong>contrastWidth</strong> <em>value</em>] [<strong>slice</strong>
-      <em>value</em>] [<strong>sliceDirection </strong><i>value</i>]</h3>
+      <em>value</em>] [<strong>contrastWidth</strong> <em>value</em>] [<strong>contrastMode</strong> <em>dol</em> | <em>lod</em>]
+      [<strong>slice</strong> <em>value</em>] [<strong>sliceDirection </strong><i>value</i>]
+      [<strong>endSlice </strong><i>value</i>] [<strong>slicePerFrame </strong><i>value</i>]
+      [<strong>pixelSize </strong><i>value</i>] </h3>
     <p> The <b>artiax tomo</b> command enables setting a property of the
       selected tomogram.</p>
     <table style="width: 764px; height: 108px;" border="1">
@@ -37,6 +39,12 @@
           <td style="width: 1580.48px; text-align: center;">N/A</td>
         </tr>
         <tr>
+          <td style="height: 19px; text-align: center;"><strong>contrastMode</strong></td>
+          <td>Whether to render with dark-on-light (default) or light-on-dark contrast</td>
+          <td style="width: 1580.48px; text-align: center;"><em>str ('dol' or 'lod')</em></td>
+          <td style="width: 1580.48px; text-align: center;">dol</td>
+        </tr>
+        <tr>
           <td style="text-align: center;"><strong>slice</strong></td>
           <td>Slice to display. Slice thickness is the grid step of the volume.
           </td>
@@ -51,7 +59,19 @@
           <td style="width: 1580.48px; text-align: center;">0,0,1</td>
         </tr>
         <tr>
-          <td style="text-align: center;"><strong>pixel</strong></td>
+          <td style="text-align: center;"><strong>endSlice</strong></td>
+          <td>If provided, slices are animated from slice to endSlice</td>
+          <td style="width: 1580.48px; text-align: center;"><em>integer</em></td>
+          <td style="width: 1580.48px; text-align: center;">N/A</td>
+        </tr>
+        <tr>
+          <td style="text-align: center;"><strong>slicePerFrame</strong></td>
+          <td>If endSlice is provided, move this many slices per frame of the animation</td>
+          <td style="width: 1580.48px; text-align: center;"><em>integer</em></td>
+          <td style="width: 1580.48px; text-align: center;">N/A</td>
+        </tr>
+        <tr>
+          <td style="text-align: center;"><strong>pixelSize</strong></td>
           <td>Pixel Size in Angstrom</td>
           <td style="width: 1580.48px; text-align: center;"><em>float</em></td>
           <td style="width: 1580.48px; text-align: center;">1</td>
@@ -59,8 +79,13 @@
       </tbody>
     </table>
     <p> Examples: </p>
-    <blockquote> <b>artiax tomo #1.1.1 slice 52&nbsp; <br>
-        artiax tomo #1.1.4 sliceDirection 1,1,1</b> </blockquote>
+    <blockquote>
+      <b>artiax tomo #1.1.1 slice 52&nbsp; <br>
+        artiax tomo #1.1.4 sliceDirection 1,1,1 <br>
+        artiax tomo #1.1.4 sliceDirection 1,1,1 endSlice 100 slicePerFrame 5 <br>
+        artiax tomo #1.1.4 pixelSize 0.5
+      </b>
+    </blockquote>
     <p></p>
     <hr>
     <address>BMLS Frangakis Group / June 2022</address>

--- a/src/toolbar/toolbar.py
+++ b/src/toolbar/toolbar.py
@@ -10,6 +10,7 @@ _providers = {
     "XZ": "artiax view xz",
     "YZ": "artiax view yz",
     "Clip": "artiax clip toggle",
+    "Invert Contrast": "artiax invert",
     "XY Models Tab": "artiax view xy",
     "XZ Models Tab": "artiax view xz",
     "YZ Models Tab": "artiax view yz",

--- a/src/util/contrast.py
+++ b/src/util/contrast.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from chimerax.core.session import Session
+from chimerax.core.models import Model
+from chimerax.core.commands import log_equivalent_command
+
+from ..volume.Tomogram import Tomogram
+
+
+def invert_contrast(session: Session, models: List[Model], log: bool = False):
+    """Invert the contrast of a list of tomograms."""
+    for model in models:
+        if isinstance(model, Tomogram):
+            if model.contrast_mode == "DARK_ON_LIGHT":
+                model.contrast_mode = "LIGHT_ON_DARK"
+            elif model.contrast_mode == "LIGHT_ON_DARK":
+                model.contrast_mode = "DARK_ON_LIGHT"
+        else:
+            session.logger.warning(f"Cannot invert contrast of {model.name}. Not a Tomogram.")
+
+    if log:
+        mnums = ','.join(m.id_string for m in models)
+        com = f"artiax invert #{mnums}"
+        log_equivalent_command(session, com)

--- a/src/util/settings.py
+++ b/src/util/settings.py
@@ -1,0 +1,12 @@
+from chimerax.core.settings import Settings
+from chimerax.core.configfile import Value
+from chimerax.core.commands import EnumOf
+
+class FullEnum(EnumOf):
+    allow_truncated = False
+
+
+class ArtiaXSettings(Settings):
+    EXPLICIT_SAVE = {'contrast': Value('DARK_ON_LIGHT', FullEnum(('DARK_ON_LIGHT', 'LIGHT_ON_DARK')), str),}
+
+    AUTO_SAVE = {}


### PR DESCRIPTION
Introduces a toolbar button that allows inverting contrast of all visible tomograms and `artiax invert` command, that can apply this action to specific models. Also contains some docs improvements. 