### PR TITLE
fix: particle deletion bug

### DIFF
--- a/src/particle/ParticleList.py
+++ b/src/particle/ParticleList.py
@@ -1301,16 +1301,13 @@ def selected_collections(session, exclude_rot_lock=False):
 
     for plist in artia.partlists.iter():
         scm = plist.collection_model
-        markers = plist.markers
 
         if plist.rotation_locked and exclude_rot_lock:
             continue
 
-        if any(plist.selected_particles):
+        if plist.selected_particles is not None and any(plist.selected_particles):
             selected_drawings.append(scm)
-            position_masks.append(
-                np.logical_or(scm.position_mask(), markers.position_mask())
-            )
+            position_masks.append(plist.selected_particles.copy())
 
     return selected_drawings, position_masks
 


### PR DESCRIPTION
In the current verison of ArtiaX / copick, when a user does the following sequence:

- place particles (any amount)
- delete particle (any amount)
- place particles (more than one)
- delete selected particles (the last selected particle, so one)

The actions work as intended. However, if a user does the following:

- place particles (any amount)
- delete particle (any amount)
- place particles again (**one**)
- delete selected particles (the last selected particle, so one)

The last delete particle, even though only intended for one particle, deletes all the particles. 

This is due to a Numpy broadcasting issue somewhere in the code, which might exist in ChimeraX. 

What ends up happening is in (see PR, or `src/particle/ParticleList.py`):

```python
            position_masks.append(
                np.logical_or(scm.position_mask(), markers.position_mask())
            )
```

the `np.logical_or()` evaluates to all true during the bugged action sequence, because `scm.position_mask()` ends up being all true, Tracing through the inherited classes, we end up with the `_position_mask` call of the Drawing class in ChimeraX, which seems to possibly be doing some broadcasting errors somewhere in the ChimeraX codebase: https://github.com/RBVI/ChimeraX/blob/56c7172631f802908efe39dda35eb8ec9a6e6baa/src/bundles/graphics/src/drawing.py#L967

```python
    def _position_mask(self, highlighted_only=False):
        dp = self._displayed_positions        # bool array
        if highlighted_only:
            sp = self._highlighted_positions
            if sp is not None:
                import numpy
                dp = sp if dp is None else numpy.logical_and(dp, sp)
        return dp
```

 I can go more down this rabbithole if desired, but the fix I've provided just skips that all entirely and just determines the `selected_particles` in a more intuitive way. 