### PR TITLE
fix: Remove stale MarkerSetPlus and tomogram reference to increase performance.

### DIFF
--- a/src/particle/MarkerSetPlus.py
+++ b/src/particle/MarkerSetPlus.py
@@ -43,7 +43,10 @@ class MarkerSetPlus(MarkerSet):
 
         # Handlers
         self.triggers.add_handler("changes", self._handle_changes)
-        self.session.triggers.add_handler('mouse hover', self._catch_hover)
+        # Keep a reference so the session-level handler can be removed on delete(); otherwise
+        # the session keeps a strong reference to this (deleted) MarkerSet forever, leaking it
+        # and firing _catch_hover on every mouse hover event indefinitely.
+        self._hover_handler = self.session.triggers.add_handler('mouse hover', self._catch_hover)
 
     def delete(self):
         # # Delete all the triggers
@@ -53,6 +56,12 @@ class MarkerSetPlus(MarkerSet):
         # self.triggers.delete_trigger(MARKER_COLOR_CHANGED)
         # self.triggers.delete_trigger(MARKER_SELECTED)
         # self.triggers.delete_trigger(MARKER_DISPLAY_CHANGED)
+
+        # Remove the session-level 'mouse hover' handler so it stops firing and stops
+        # keeping this deleted MarkerSet (and its ParticleList) alive.
+        if getattr(self, "_hover_handler", None) is not None:
+            self.session.triggers.remove_handler(self._hover_handler)
+            self._hover_handler = None
 
         # Delete self
         MarkerSet.delete(self)

--- a/src/volume/Tomogram.py
+++ b/src/volume/Tomogram.py
@@ -68,10 +68,23 @@ class Tomogram(VolumePlus):
 
         # Whether to clip a slab around this tomogram
         self._is_clipped = False
-        self.triggers.add_handler(RENDERING_OPTIONS_CHANGED, self.update_clip)
+        # Keep a reference so the handler can be removed on delete(). update_clip is a bound
+        # method of this Tomogram, so registering it on the tomogram's own trigger set creates
+        # a reference cycle; removing it on delete() lets the (large) tomogram be freed promptly
+        # by refcounting instead of waiting for a cyclic GC pass.
+        self._rendering_options_handler = self.triggers.add_handler(RENDERING_OPTIONS_CHANGED, self.update_clip)
 
         # Update display
         self.update_drawings()
+
+    def delete(self):
+        # Break the self-referential handler cycle before deleting so this tomogram's volume
+        # data is released immediately rather than lingering until cyclic garbage collection.
+        if getattr(self, "_rendering_options_handler", None) is not None:
+            self.triggers.remove_handler(self._rendering_options_handler)
+            self._rendering_options_handler = None
+
+        super().delete()
 
     @property
     def pixelsize(self):


### PR DESCRIPTION
Stale references of deleted objects were kept in global triggerset, decreasing performance on long picking sessions. This PR introduces a fix, properly cleaning up triggersets when objects are deleted.