### PR TITLE
Fix RELION & RELION5 star file import for ChimeraX 1.10.1

### DIFF
--- a/src/io/RELION/RELIONParticleData.py
+++ b/src/io/RELION/RELIONParticleData.py
@@ -264,7 +264,7 @@ class RELIONParticleData(ParticleData):
         # Additional data (everything that is a number)
         additional_entries = []
         for key in additional_keys:
-            if np.issubdtype(df.dtypes[key], np.number):
+            if pd.api.types.is_numeric_dtype(df.dtypes[key]):
                 additional_entries.append(key)
                 self._data_keys[key] = []
             else:

--- a/src/io/RELION5/RELION5ParticleData.py
+++ b/src/io/RELION5/RELION5ParticleData.py
@@ -302,7 +302,7 @@ class RELION5ParticleData(ParticleData):
         # Additional data (everything that is a number)
         additional_entries = []
         for key in additional_keys:
-            if np.issubdtype(df.dtypes[key], np.number):
+            if pd.api.types.is_numeric_dtype(df.dtypes[key]):
                 additional_entries.append(key)
                 self._data_keys[key] = []
             else:


### PR DESCRIPTION
Fixes #43. Supersedes #44.

## Problem
ChimeraX 1.10.1 ships a newer pandas where the `starfile` reader returns string columns (e.g. `rlnMicrographName`) as the pandas extension `StringDtype` instead of numpy `object`. `np.issubdtype()` only understands numpy dtypes, so classifying the "additional" columns during import raises:

```
TypeError: Cannot interpret '<StringDtype(na_value=nan)>' as a data type
```

## Fix
Replace the check with pandas' public `pd.api.types.is_numeric_dtype()`, which correctly handles both numpy dtypes and pandas extension dtypes.

The identical check existed in **both** star-file readers, so the fix is applied in both:
- `src/io/RELION/RELIONParticleData.py` — original fix by @bwmr (from #44)
- `src/io/RELION5/RELION5ParticleData.py` — the RELION5 reader had the same line and would crash the same way on RELION5 star files

Credit to @bwmr for the root-cause analysis and the original fix in #43/#44; their commit is preserved here. This PR bundles the matching RELION5 fix so #43 is fully resolved (rebased onto current `main`, which now includes #39 and #52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)